### PR TITLE
Update to spring boot 2.7.0 and minio 8.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.3</version>
+        <version>2.7.0</version>
     </parent>
 
     <groupId>com.jlefebure</groupId>
@@ -31,7 +31,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <minio.version>8.1.0</minio.version>
+        <minio.version>8.4.1</minio.version>
     </properties>
 
     <version>1.11-SNAPSHOT</version>
@@ -96,33 +96,28 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
-            <scope>provided</scope>
             <version>${minio.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
 

--- a/src/main/java/com/jlefebure/spring/boot/minio/MinioNotificationConfiguration.java
+++ b/src/main/java/com/jlefebure/spring/boot/minio/MinioNotificationConfiguration.java
@@ -29,9 +29,11 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -57,8 +59,15 @@ public class MinioNotificationConfiguration implements ApplicationContextAware {
         this.minioConfigurationProperties = minioConfigurationProperties;
     }
 
+    private ApplicationContext applicationContext;
+
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void listenNotification() throws BeansException {
         for (String beanName : applicationContext.getBeanDefinitionNames()) {
             Object obj = applicationContext.getBean(beanName);
 


### PR DESCRIPTION
Proposing fix on the pom to remove scope provided as it is causing issue a project import 1.10 version.
Update to latest spring boot 2.7.0 and minio 8.4.1.
Fix issue when listen to notification. On latest spring boot , seems setApplicationContext method of ApplicationContextAware is not called after all bean is created. Create a new method, listenNotification, that will be invoked after application receive Event ApplicationReadyEvent.
